### PR TITLE
Update isolated_server to 0.4.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 cache: bundler
-sudo: false
+
+sudo: required
+
 language: ruby
+
 rvm:
-  - 2.1
   - 2.2
+  - 2.3
+  - 2.4
+
 script: bundle exec rspec
+
+before_script:
+  - sudo cp /usr/share/doc/mysql-server-5.6/examples/my-default.cnf /usr/share/mysql/my-default.cnf
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     backports (3.6.7)
     bump (0.5.3)
     diff-lcs (1.2.5)
-    isolated_server (0.4.11)
+    isolated_server (0.4.12)
     multi_json (1.11.2)
     mysql2 (0.4.2)
     rack (1.6.4)
@@ -67,4 +67,4 @@ DEPENDENCIES
   sinatra-contrib
 
 BUNDLED WITH
-   1.13.2
+   1.14.3


### PR DESCRIPTION
This updated isolated_server to the newer version that has slightly better debugging output, and fixes the Travis build using a `before_script` that installs my-default.cnf in the right location.